### PR TITLE
Add Rust rock paper scissors as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "architecture/2018_03_maintainability_by_removing_if/by_language/rust/rock-paper-scissors"]
+	path = architecture/2018_03_maintainability_by_removing_if/by_language/rust/rock-paper-scissors
+	url = https://github.com/pawroman/rock-paper-scissors


### PR DESCRIPTION
The rules of the game can be summarised in these two functions:
```rust
impl Beats for Hand {
    fn beats(&self) -> Self {
        // match is exhaustive, so every enum variant must be covered
        match *self {
            Rock => Scissors,
            Paper => Rock,
            Scissors => Paper,
        }
    }
}

pub fn play_hand(own_hand: Hand, other_hand: Hand) -> HandResult {
    let (own_beats, other_beats) = (own_hand.beats(), other_hand.beats());

    match (own_beats, other_beats) {
        _ if own_beats == other_hand => Win,
        _ if other_beats == own_hand => Lose,
        _                            => Draw,
    }
}
```