### PR TITLE
Adding a `guvectorized` approach to LUD

### DIFF
--- a/performance/2017_12_LU_decomposition/python/lu_vectorized.py
+++ b/performance/2017_12_LU_decomposition/python/lu_vectorized.py
@@ -1,0 +1,77 @@
+from numba import guvectorize
+import numpy as np
+
+
+@guvectorize(
+    ['void(float64[:, :], int64, int64, float64[:, :], float64[:, :])'],
+    '(x, y), (), (), (m, n)->(m, n)',
+    target='cpu', nopython=True
+)
+def upper_inner(x, i, n, lower, upper):
+    for k in range(i, n):
+        total = 0.0
+        for j in range(i):
+            total += lower[i][j] * upper[j][k]
+
+        upper[i][k] = x[i][k] - total
+
+
+@guvectorize(
+    ['void(float64[:, :], int64, int64, float64[:, :], float64[:, :])'],
+    '(x, y), (), (), (m, n)->(m, n)',
+    target='cpu', nopython=True
+)
+def lower_inner(x, i, n, lower, upper):
+    for k in range(i + 1, n):
+        total = 0.0
+        for j in range(i):
+            total += lower[k][j] * upper[j][i]
+
+        lower[k][i] = (x[k][i] - total) / upper[i][i]
+
+
+def lu_vectorized(x):
+    upper = np.asfortranarray(np.zeros(x.shape, dtype=np.float64))
+    n = len(x)
+    lower = np.eye(len(x))
+
+    for i in range(n):
+        upper_inner(x, i, n, lower, upper)
+        lower_inner(x, i, n, lower, upper)
+
+    return lower, upper
+
+
+# I don't think this is actually supposed to work, the signature
+# says we're just 'returning' one new array, but both lower and
+# upper are mutated?
+@guvectorize(
+    ['void(float64[:, :], float64[:, :], float64[:, :])'],
+    '(x, y), (m, n)->(m, n)',
+    target='cpu', nopython=True
+)
+def inner(x, lower, upper):
+    n = len(x)
+    for i in range(n):
+        for k in range(i, n):
+            total = 0.0
+            for j in range(i):
+                total += lower[i][j] * upper[j][k]
+
+            upper[i][k] = x[i][k] - total
+
+        for k in range(i + 1, n):
+            total = 0.0
+            for j in range(i):
+                total += lower[k][j] * upper[j][i]
+
+            lower[k][i] = (x[k][i] - total) / upper[i][i]
+
+
+def lu_vectorized_experimental(x):
+    upper = np.asfortranarray(np.zeros(x.shape, dtype=np.float64))
+    lower = np.eye(len(x))
+
+    inner(x, lower, upper)
+
+    return lower, upper

--- a/performance/2017_12_LU_decomposition/python/profile_and_plot.py
+++ b/performance/2017_12_LU_decomposition/python/profile_and_plot.py
@@ -14,18 +14,18 @@ from lu_smorgasbord import (
     lu_parallel, lu_parallel_2
 )
 from lu_c_fortran import lu_decomp_c_fortran
-
+from lu_vectorized import lu_vectorized, lu_vectorized_experimental
 
 if __name__ == '__main__':
     np.random.seed(0)
 
     lu_decomp_python = lu_decomp
 
-    def collect_results(fn, jit=True):
-        if jit:
+    def collect_results(fn, fast=True, should_jit=True):
+        if fast:
             sizes = (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 2000)
 
-            if not isinstance(fn, numba.targets.registry.CPUDispatcher):
+            if should_jit and not isinstance(fn, numba.targets.registry.CPUDispatcher):
                 fn = njit(fn)
 
             fn(np.random.random((10, 10)))  # force compile
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         raw_df = pd.DataFrame(raw_results, columns=['idx', 'vals']).set_index('idx')
         return raw_df
 
-    df = collect_results(lu_decomp_python, jit=False)
+    df = collect_results(lu_decomp_python, fast=False, should_jit=False)
     plt.loglog(df, label=lu_decomp_python.__name__)
 
     # jitted functions
@@ -57,8 +57,12 @@ if __name__ == '__main__':
            lu_3, lu_4, lu_5, lu_parallel, lu_parallel_2]
 
     for fn in fns:
-        df = collect_results(fn)
-        plt.loglog(df, label=fn.__name__)
+        plt.loglog(collect_results(fn), label=fn.__name__)
+
+    # We don't want to jit our vectorized functions, as calling guvectorized
+    # functions from a jitted function is troublesome and not currently well supported
+    for fn in [lu_vectorized, lu_vectorized_experimental]:
+        plt.loglog(collect_results(fn, should_jit=False), label=fn.__name__)
 
     plt.xlabel('Length of array axis (n)')
     plt.ylabel('Calculation time (s)')


### PR DESCRIPTION
So, the results of this approach aren't impressive (slower than @rjenc29, as usual 😄), but it was a good learning experience and feels like the start of an approach that might work well in the future with some touching up.

![vectorized_results](https://user-images.githubusercontent.com/5992653/50731555-e7cc4500-115f-11e9-9237-c0fa30cdce0c.png)

As you can see, it falls somewhere in the middle of the jitted approaches, I suspect things aren't actually being vectorized, but don't know enough about the numba internals to be able to inspect (will work on that).

I will try this on a CUDA friendly GPU soon, that may give interesting results if we can get it to be properly vectorized.

As an aside - `lu_vectorized_experimental ` is quite interesting, my understanding is that it should fail, but it does work and has very similar speeds. If I'm missing something let me know!